### PR TITLE
Sponsors: Fix typo in mail address

### DIFF
--- a/theme/pycones23/templates/patrocinios.html
+++ b/theme/pycones23/templates/patrocinios.html
@@ -8,8 +8,8 @@
       ¿Te gustaría patrocinar la próxima edición del evento mas importante sobre
       desarrollo software con Python? No lo dudes y ponte ya mismo en contacto
       con la organización escribiendo al correo
-      <a class="link" href="mailto:sponsor@2023.es.pycon.org"
-        >sponsor@2023.es.pycon.org</a
+      <a class="link" href="mailto:sponsors@2023.es.pycon.org"
+        >sponsors@2023.es.pycon.org</a
       >
       Para conocer todas las ventajas que te ofrecen nuestros distintos niveles
       de patrocinio puedes descargar el folleto informativo:


### PR DESCRIPTION
The current mail address is `sponsors at 2023.es.pycon.org`. However, the one displayed on the sponsorship webpage is the "old" one: `sponsor at 2023.es.pycon.org`. This makes the possible partners' mails to be lost, not being able to answer them back.