### PR TITLE
Noticias leidas desde ficheros markdown en la carpeta noticias

### DIFF
--- a/config/web.py
+++ b/config/web.py
@@ -1,5 +1,7 @@
 import random
 
+import noticias
+
 AUTHOR = 'Python España'
 SITENAME = 'PyConES23'
 
@@ -306,18 +308,7 @@ PATROCINADORES = {
 
 # NOTICIAS
 
-NOTICIAS = [
-    {
-        "titulo": "¡Ya puedes comprar tus entradas!",
-        "fecha": "5/5/2023",
-        "contenido": "¡Por fin ha llegado el día! Ya están aquí las entradas del evento más esperado del año de la comunidad Python en España",
-    },
-    {
-        "titulo": "¡Lanzamiento del sitio web!",
-        "fecha": "4/12/2023",
-        "contenido": "Os damos la bienvenida a la PyConES, la conferencia de Python más importante de España. Un evento que reunirá a cientos de entusiastas del lenguaje de programación Python, con una agenda increíble en la mejor localización posible. Si quieres formar parte de nuestros patrocinadores para hacer esta conferencia aún mas impresionante puedes disponer de espacio propio dentro del evento.",
-    },
-]
+NOTICIAS = noticias.ultimas_noticias()
 
 ORG = [
     {

--- a/noticias.py
+++ b/noticias.py
@@ -1,0 +1,39 @@
+import glob
+from datetime import date as Date
+from dataclasses import dataclass
+
+import markdown
+
+
+@dataclass
+class Noticia:
+    titulo: str
+    fecha: Date
+    contenido: str
+
+
+def _iter_noticias():
+    news_parser = markdown.Markdown(extensions=['extra', 'meta'])
+    for filename in glob.glob('noticias/*.md'):
+        news_parser.reset()
+        with open(filename, 'r', encoding='utf-8') as f:
+            contenido = news_parser.convert(f.read())
+            yield Noticia(
+                titulo=news_parser.Meta['titulo'][0],
+                fecha=Date.fromisoformat(news_parser.Meta['fecha'][0]),
+                contenido=contenido,
+                )
+
+
+def ultimas_noticias(max_noticias=5):
+    news = sorted(_iter_noticias(), reverse=True, key=lambda d: d.fecha)
+    return news[0:max_noticias]
+
+
+def main():
+    for noticia in ultimas_noticias():
+        print(noticia.fecha, noticia.titulo)
+
+
+if __name__ == "__main__":
+    main()

--- a/noticias/entradas-2023-05-05.md
+++ b/noticias/entradas-2023-05-05.md
@@ -1,0 +1,7 @@
+---
+titulo: ¡Ya puedes comprar tus entradas!
+fecha: 2023-05-05
+---
+
+**¡Por fin ha llegado el día!** Ya están aquí las entradas del evento más
+esperado del año de la comunidad Python en España.

--- a/noticias/web-2023-04-12.md
+++ b/noticias/web-2023-04-12.md
@@ -1,0 +1,9 @@
+---
+titulo: ¡Lanzamiento del sitio web!
+fecha: 2023-04-12
+---
+Os damos la bienvenida a la PyConES, la conferencia de Python más importante de
+España. Un evento que reunirá a cientos de entusiastas del lenguaje de
+programación Python, con una agenda increíble en la mejor localización posible.
+Si quieres formar parte de nuestros patrocinadores para hacer esta conferencia
+aún mas impresionante puedes disponer de espacio propio dentro del evento.

--- a/theme/pycones23/static/assets/css/main.css
+++ b/theme/pycones23/static/assets/css/main.css
@@ -894,3 +894,8 @@ a.boton-reserva {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
+
+.fecha {
+    font-size: 90%;
+    color: #edd3c5;
+}

--- a/theme/pycones23/templates/index.html
+++ b/theme/pycones23/templates/index.html
@@ -22,7 +22,10 @@
 
 {% for noticia in NOTICIAS %}
 <div class="news-box">
-   <div class="news-title">{{ noticia.titulo }} <span>{{ noticia.fecha }}</span></div>
+   <div class="news-title">{{ noticia.titulo }}
+       <br><small><span class="fecha">
+            {{ noticia.fecha.strftime('%d/%b/%Y') }}
+           </span></small></div>
    <div class="news-content">
       {{ noticia.contenido }}
    </div>


### PR DESCRIPTION
Las noticias se pueden crear ahora simplemente añadiendo un fichero en markdown en la carpeta `noticias`.

El fichero de noticias debe tener un uncabezado con meta información, los campos `titutlo` y `fecha` de la noticia. Los metadatos van al principio del fichero enmarcados por las secuencias de caracteres `---`, luego viene un salto de linea y a continuación, el texto de la noticia, que puede usar markdown.

Un ejemplo de notticia:

```md
---
titulo: ¡Ya puedes comprar tus entradas!
fecha: 2023-05-05
---

**¡Por fin ha llegado el día!** Ya están aquí las entradas del evento más
esperado del año de la comunidad Python en España.
```

### Notas

- El campo `fecha` debe estar on formato ISO: `<year>-<month>-<day>`, con los días o meses inferiores a 9 rellenos con un cero. Es decir, `2023-6-3` no es válido, habría que usar `2023-06-03`.

- Las notas anteriores se han migrado como ficheros en la carpeta `noticias/`
